### PR TITLE
Update to work with notmuch 0.26

### DIFF
--- a/db.go
+++ b/db.go
@@ -149,8 +149,7 @@ func (db *DB) AddMessage(filename string) (*Message, error) {
 	defer C.free(unsafe.Pointer(cfilename))
 
 	var cmsg *C.notmuch_message_t
-	var copts = C.notmuch_database_get_default_indexopts(db.toC())
-	if err := statusErr(C.notmuch_database_index_file(db.toC(), cfilename, copts, &cmsg)); err != nil {
+	if err := statusErr(C.notmuch_database_index_file(db.toC(), cfilename, nil, &cmsg)); err != nil {
 		return nil, err
 	}
 	msg := &Message{

--- a/db.go
+++ b/db.go
@@ -149,7 +149,8 @@ func (db *DB) AddMessage(filename string) (*Message, error) {
 	defer C.free(unsafe.Pointer(cfilename))
 
 	var cmsg *C.notmuch_message_t
-	if err := statusErr(C.notmuch_database_add_message(db.toC(), cfilename, &cmsg)); err != nil {
+	var copts = C.notmuch_database_get_default_indexopts(db.toC())
+	if err := statusErr(C.notmuch_database_index_file(db.toC(), cfilename, copts, &cmsg)); err != nil {
 		return nil, err
 	}
 	msg := &Message{

--- a/db_test.go
+++ b/db_test.go
@@ -88,7 +88,7 @@ func TestNeedsUpgrade(t *testing.T) {
 	}
 	defer db.Close()
 	if want, got := false, db.NeedsUpgrade(); want != got {
-		t.Errorf("db.NeedsUpgrade(): want %b got %b", want, got)
+		t.Errorf("db.NeedsUpgrade(): want %t got %t", want, got)
 	}
 }
 

--- a/query.go
+++ b/query.go
@@ -33,7 +33,7 @@ func (q *Query) String() string {
 // Threads returns the threads matching the query.
 func (q *Query) Threads() (*Threads, error) {
 	var cthreads *C.notmuch_threads_t
-	err := statusErr(C.notmuch_query_search_threads_st(q.toC(), &cthreads))
+	err := statusErr(C.notmuch_query_search_threads(q.toC(), &cthreads))
 	if err != nil {
 		return nil, err
 	}
@@ -47,10 +47,14 @@ func (q *Query) Threads() (*Threads, error) {
 
 // CountThreads returns the number of messages for the current query.
 func (q *Query) CountThreads() int {
-	return int(C.notmuch_query_count_threads(q.toC()))
+	var ccount C.uint
+	C.notmuch_query_count_threads(q.toC(), &ccount)
+	return int(ccount)
 }
 
 // CountMessages returns the number of messages for the current query.
 func (q *Query) CountMessages() int {
-	return int(C.notmuch_query_count_messages(q.toC()))
+	var cCount C.uint
+	C.notmuch_query_count_messages(q.toC(), &cCount)
+	return int(cCount)
 }


### PR DESCRIPTION
On attempting to use go.notmuch  I got errors due to updated and/or deprecated functions being called in the notmuch library. Have updated the library calls to use the newer notmuch API.

Changes have been tested under Ubuntu 18.04 using notmuch 0.26.

Hope this helps :)