### PR TITLE
Add config api

### DIFF
--- a/configList.go
+++ b/configList.go
@@ -12,11 +12,6 @@ import "C"
 // Messages represents a notmuch config list
 type ConfigList cStruct
 
-//ConfigOption is used as a container for key / value pairs of the ConfigList
-type ConfigOption struct {
-	Key, Value string
-}
-
 func (cl *ConfigList) Close() error {
 	return (*cStruct)(cl).doClose(func() error {
 		C.notmuch_config_list_destroy(cl.toC())
@@ -28,13 +23,15 @@ func (cl *ConfigList) toC() *C.notmuch_config_list_t {
 	return (*C.notmuch_config_list_t)(cl.cptr)
 }
 
-// Next retrieves the nex ConfigOption from the ConfigList.
-// Next returns true if a ConfigOption was successfully retrieved.
-func (cl *ConfigList) Next(opt **ConfigOption) bool {
+// Next retrieves the nex config pair from the ConfigList.
+// Neither key, nor value must be nil, or this function will panic.
+// Next returns true if a pair was successfully retrieved.
+func (cl *ConfigList) Next(key, value *string) bool {
 	if !cl.valid() {
 		return false
 	}
-	*opt = cl.getOption()
+	*key = cl.key()
+	*value = cl.value()
 	C.notmuch_config_list_move_to_next(cl.toC())
 	return true
 }
@@ -42,13 +39,6 @@ func (cl *ConfigList) Next(opt **ConfigOption) bool {
 func (cl *ConfigList) valid() bool {
 	cbool := C.notmuch_config_list_valid(cl.toC())
 	return int(cbool) != 0
-}
-
-func (cl *ConfigList) getOption() *ConfigOption {
-	var opt ConfigOption
-	opt.Key = cl.key()
-	opt.Value = cl.value()
-	return &opt
 }
 
 func (cl *ConfigList) key() string {

--- a/configList.go
+++ b/configList.go
@@ -1,0 +1,60 @@
+package notmuch
+
+// Copyright © 2015 The go.notmuch Authors. Authors can be found in the AUTHORS file.
+// Licensed under the GPLv3 or later.
+// See COPYING at the root of the repository for details.
+
+// #cgo LDFLAGS: -lnotmuch
+// #include <stdlib.h>
+// #include <notmuch.h>
+import "C"
+
+// Messages represents a notmuch config list
+type ConfigList cStruct
+
+//ConfigOption is used as a container for key / value pairs of the ConfigList
+type ConfigOption struct {
+	Key, Value string
+}
+
+func (cl *ConfigList) Close() error {
+	return (*cStruct)(cl).doClose(func() error {
+		C.notmuch_config_list_destroy(cl.toC())
+		return nil
+	})
+}
+
+func (cl *ConfigList) toC() *C.notmuch_config_list_t {
+	return (*C.notmuch_config_list_t)(cl.cptr)
+}
+
+// Next retrieves the nex ConfigOption from the ConfigList.
+// Next returns true if a ConfigOption was successfully retrieved.
+func (cl *ConfigList) Next(opt **ConfigOption) bool {
+	if !cl.valid() {
+		return false
+	}
+	*opt = cl.getOption()
+	C.notmuch_config_list_move_to_next(cl.toC())
+	return true
+}
+
+func (cl *ConfigList) valid() bool {
+	cbool := C.notmuch_config_list_valid(cl.toC())
+	return int(cbool) != 0
+}
+
+func (cl *ConfigList) getOption() *ConfigOption {
+	var opt ConfigOption
+	opt.Key = cl.key()
+	opt.Value = cl.value()
+	return &opt
+}
+
+func (cl *ConfigList) key() string {
+	return C.GoString(C.notmuch_config_list_key(cl.toC()))
+}
+
+func (cl *ConfigList) value() string {
+	return C.GoString(C.notmuch_config_list_value(cl.toC()))
+}

--- a/db.go
+++ b/db.go
@@ -262,9 +262,5 @@ func (db *DB) SetConfig(key, value string) error {
 	cval := C.CString(value)
 	defer C.free(unsafe.Pointer(cval))
 
-	err := statusErr(C.notmuch_database_set_config(db.toC(), ckey, cval))
-	if err != nil {
-		return err
-	}
-	return nil
+	return statusErr(C.notmuch_database_set_config(db.toC(), ckey, cval))
 }

--- a/db.go
+++ b/db.go
@@ -242,8 +242,8 @@ func (db *DB) GetConfigList(prefix string) (*ConfigList, error) {
 	return cl, nil
 }
 
-// GetConfigOption gets config value of key
-func (db *DB) GetConfigOption(key string) (string, error) {
+// GetConfig gets config value of key
+func (db *DB) GetConfig(key string) (string, error) {
 	ckey := C.CString(key)
 	defer C.free(unsafe.Pointer(ckey))
 	var cval *C.char
@@ -255,8 +255,8 @@ func (db *DB) GetConfigOption(key string) (string, error) {
 	return C.GoString(cval), nil
 }
 
-// SetConfigOption sets config key to value.
-func (db *DB) SetConfigOption(key, value string) error {
+// SetConfig sets config key to value.
+func (db *DB) SetConfig(key, value string) error {
 	ckey := C.CString(key)
 	defer C.free(unsafe.Pointer(ckey))
 	cval := C.CString(value)

--- a/db.go
+++ b/db.go
@@ -247,11 +247,11 @@ func (db *DB) GetConfig(key string) (string, error) {
 	ckey := C.CString(key)
 	defer C.free(unsafe.Pointer(ckey))
 	var cval *C.char
-	defer C.free(unsafe.Pointer(cval))
 	err := statusErr(C.notmuch_database_get_config(db.toC(), ckey, &cval))
 	if err != nil {
 		return "", err
 	}
+	defer C.free(unsafe.Pointer(cval))
 	return C.GoString(cval), nil
 }
 

--- a/db.go
+++ b/db.go
@@ -247,6 +247,7 @@ func (db *DB) GetConfigOption(key string) (string, error) {
 	ckey := C.CString(key)
 	defer C.free(unsafe.Pointer(ckey))
 	var cval *C.char
+	defer C.free(unsafe.Pointer(cval))
 	err := statusErr(C.notmuch_database_get_config(db.toC(), ckey, &cval))
 	if err != nil {
 		return "", err

--- a/db_test.go
+++ b/db_test.go
@@ -242,19 +242,19 @@ func TestSetConfig(t *testing.T) {
 	defer db.Close()
 	cfgKey := "search.exclude_tags"
 	cfgVal := "spam"
-	if err := db.SetConfigOption(cfgKey, cfgVal); err != nil {
-		t.Errorf("db.SetConfigOption(%q, %q): unexpected error %s", cfgKey, cfgVal, err)
+	if err := db.SetConfig(cfgKey, cfgVal); err != nil {
+		t.Errorf("db.SetConfig(%q, %q): unexpected error %s", cfgKey, cfgVal, err)
 	}
 }
 
-func TestGetConfigOption(t *testing.T) {
+func TestGetConfig(t *testing.T) {
 	db, err := Open(dbPath, DBReadWrite)
 	if err != nil {
 		t.Fatalf("Open(%q): unexpected error: %s", dbPath, err)
 	}
 	defer db.Close()
-	if _, err := db.GetConfigOption("blah"); err != nil {
-		t.Errorf("db.GetConfigOption(\"blah\"): unexpected error %s", err)
+	if _, err := db.GetConfig("blah"); err != nil {
+		t.Errorf("db.GetConfig(\"blah\"): unexpected error %s", err)
 	}
 }
 
@@ -266,15 +266,15 @@ func TestConfigRoundtrip(t *testing.T) {
 	defer db.Close()
 	cfgKey := "search.exclude_tags"
 	cfgVal := "spam"
-	if err := db.SetConfigOption(cfgKey, cfgVal); err != nil {
-		t.Errorf("db.SetConfigOption(%q, %q): unexpected error %s", cfgKey, cfgVal, err)
+	if err := db.SetConfig(cfgKey, cfgVal); err != nil {
+		t.Errorf("db.SetConfig(%q, %q): unexpected error %s", cfgKey, cfgVal, err)
 	}
-	value, err := db.GetConfigOption(cfgKey)
+	value, err := db.GetConfig(cfgKey)
 	if err != nil {
-		t.Errorf("db.GetConfigOption(%q): unexpected error %s", cfgKey, err)
+		t.Errorf("db.GetConfig(%q): unexpected error %s", cfgKey, err)
 	}
 	if value != cfgVal {
-		t.Errorf("db.GetConfigOption(%q): want: %q, got %q", cfgKey, cfgVal, value)
+		t.Errorf("db.GetConfig(%q): want: %q, got %q", cfgKey, cfgVal, value)
 	}
 }
 
@@ -286,8 +286,8 @@ func TestConfigListNext(t *testing.T) {
 	defer db.Close()
 	cfgKey := "search.exclude_tags"
 	cfgVal := "spam"
-	if err := db.SetConfigOption(cfgKey, cfgVal); err != nil {
-		t.Errorf("db.SetConfigOption(%q, %q): unexpected error %s", cfgKey, cfgVal, err)
+	if err := db.SetConfig(cfgKey, cfgVal); err != nil {
+		t.Errorf("db.SetConfig(%q, %q): unexpected error %s", cfgKey, cfgVal, err)
 	}
 	cfgList, err := db.GetConfigList("")
 	if err != nil {

--- a/db_test.go
+++ b/db_test.go
@@ -293,12 +293,9 @@ func TestConfigListNext(t *testing.T) {
 	if err != nil {
 		t.Fatalf("db.GetConfigList(%q): unexpected error: %s", "", err)
 	}
-	var opt *ConfigOption
 	var resKey string
 	var resVal string
-	for cfgList.Next(&opt) {
-		resKey = opt.Key
-		resVal = opt.Value
+	for cfgList.Next(&resKey, &resVal) {
 		break
 	}
 	if resKey != cfgKey {
@@ -307,7 +304,7 @@ func TestConfigListNext(t *testing.T) {
 	if resVal != cfgVal {
 		t.Errorf("config value: expected %q, got %q", cfgVal, resVal)
 	}
-	if cfgList.Next(&opt) {
+	if cfgList.Next(&resKey, &resVal) {
 		t.Errorf("iteration did not stop after the end of the options")
 	}
 }


### PR DESCRIPTION
This is the implementation of the config api notmuch provides.

I've kept the`ConfigList.Next(**ConfigOption)` api, so that the interface is the same across Messages / Threads and now configs. Even though it isn't really needed.