### PR TITLE
Add support for notmuch properties

### DIFF
--- a/message.go
+++ b/message.go
@@ -117,6 +117,50 @@ func (m *Message) RemoveAllTags() error {
 	return statusErr(C.notmuch_message_remove_all_tags(m.toC()))
 }
 
+// Properties returns the properties for the current message, returning a
+// *MessageProperties which can be used to iterate over all properties using
+// `MessageProperties.Next(MessageProperty)`
+func (m *Message) Properties(key string, exact bool) *MessageProperties {
+	cexact := 0
+	if exact {
+		cexact = 1
+	}
+	ckey := C.CString(key)
+	defer C.free(unsafe.Pointer(ckey))
+	cprops := C.notmuch_message_get_properties(m.toC(), ckey, C.int(cexact))
+	props := &MessageProperties{
+		cptr:   unsafe.Pointer(cprops),
+		parent: (*cStruct)(m),
+	}
+	setGcClose(props)
+	return props
+}
+
+// AddProperty adds a property to the message.
+func (m *Message) AddProperty(key string, value string) error {
+	ckey := C.CString(key)
+	defer C.free(unsafe.Pointer(ckey))
+	cvalue := C.CString(value)
+	defer C.free(unsafe.Pointer(cvalue))
+	return statusErr(C.notmuch_message_add_property(m.toC(), ckey, cvalue))
+}
+
+// RemoveProperty removes a key/value pair from the message properties.
+func (m *Message) RemoveProperty(key string, value string) error {
+	ckey := C.CString(key)
+	defer C.free(unsafe.Pointer(ckey))
+	cvalue := C.CString(value)
+	defer C.free(unsafe.Pointer(cvalue))
+	return statusErr(C.notmuch_message_remove_property(m.toC(), ckey, cvalue))
+}
+
+// RemoveAllProperties removes all properties with key from the message.
+func (m *Message) RemoveAllProperties(key string) error {
+	ckey := C.CString(key)
+	defer C.free(unsafe.Pointer(ckey))
+	return statusErr(C.notmuch_message_remove_all_properties(m.toC(), ckey))
+}
+
 // Atomic allows a transactional change of tags to the message.
 func (m *Message) Atomic(callback func(*Message)) error {
 	if err := statusErr(C.notmuch_message_freeze(m.toC())); err != nil {

--- a/message_properties.go
+++ b/message_properties.go
@@ -1,0 +1,62 @@
+package notmuch
+
+// Copyright © 2015 The go.notmuch Authors. Authors can be found in the AUTHORS file.
+// Licensed under the GPLv3 or later.
+// See COPYING at the root of the repository for details.
+
+// #cgo LDFLAGS: -lnotmuch
+// #include <stdlib.h>
+// #include <notmuch.h>
+import "C"
+
+// MessageProperties represent a notmuch properties type.
+type MessageProperties cStruct
+
+func (props *MessageProperties) toC() *C.notmuch_message_properties_t {
+	return (*C.notmuch_message_properties_t)(props.cptr)
+}
+
+func (props *MessageProperties) Close() error {
+	return (*cStruct)(props).doClose(func() error {
+		C.notmuch_message_properties_destroy(props.toC())
+		return nil
+	})
+}
+
+// Next retrieves the next prop from the result set. Next returns true if a prop
+// was successfully retrieved.
+func (props *MessageProperties) Next(p **MessageProperty) bool {
+	if !props.valid() {
+		return false
+	}
+	*p = props.get()
+	C.notmuch_message_properties_move_to_next(props.toC())
+	return true
+}
+
+// Return a slice of strings containing each element of props.
+func (props *MessageProperties) slice() []string {
+	var prop *MessageProperty
+	ret := []string{}
+	for props.Next(&prop) {
+		ret = append(ret, prop.Value)
+	}
+	return ret
+}
+
+func (props *MessageProperties) get() *MessageProperty {
+	ckey := C.notmuch_message_properties_key(props.toC())
+	cvalue := C.notmuch_message_properties_value(props.toC())
+
+	prop := &MessageProperty{
+		Key:        C.GoString(ckey),
+		Value:      C.GoString(cvalue),
+		properties: props,
+	}
+	return prop
+}
+
+func (props *MessageProperties) valid() bool {
+	cbool := C.notmuch_message_properties_valid(props.toC())
+	return int(cbool) != 0
+}

--- a/message_properties_test.go
+++ b/message_properties_test.go
@@ -1,0 +1,39 @@
+package notmuch
+
+import (
+	"testing"
+)
+
+func TestMessagesProperties(t *testing.T) {
+	db, err := Open(dbPath, DBReadWrite)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	qs := "subject:\"Introducing myself\""
+	messages, err := db.NewQuery(qs).Messages()
+	if err != nil {
+		t.Fatalf("error getting the messages: %s", err)
+	}
+
+	first := &Message{}
+	found := messages.Next(&first)
+	if !found {
+		t.Fatalf("couldn't get the first message: %s", err)
+	}
+
+	if err := first.AddProperty("go-notmuch-test", "success"); err != nil {
+		t.Fatalf("couldn't add property: %s", err)
+	}
+
+	properties := first.Properties("go-notmuch-test", true)
+	property := &MessageProperty{}
+	for properties.Next(&property) {
+		if property.Key == "go-notmuch-test" && property.Value == "success" {
+			return
+		}
+	}
+
+	t.Fatalf("couldn't find expected property")
+}

--- a/message_property.go
+++ b/message_property.go
@@ -1,0 +1,21 @@
+package notmuch
+
+// Copyright © 2015 The go.notmuch Authors. Authors can be found in the AUTHORS file.
+// Licensed under the GPLv3 or later.
+// See COPYING at the root of the repository for details.
+
+// #cgo LDFLAGS: -lnotmuch
+// #include <stdlib.h>
+// #include <notmuch.h>
+import "C"
+
+// MessageProperty represents a property in the database.
+type MessageProperty struct {
+	Key        string
+	Value      string
+	properties *MessageProperties
+}
+
+func (p *MessageProperty) String() string {
+	return p.Key + "=" + p.Value
+}


### PR DESCRIPTION
I'd like to have this interface for [go-imap-notmuch](https://github.com/stbenjam/go-imap-notmuch) to store an [IMAP UID](https://datatracker.ietf.org/doc/html/rfc3501#section-2.3.1.1) which has to be remembered.

From https://git.notmuchmail.org/git/notmuch/blob/HEAD:/lib/notmuch.h:

```
This interface provides the ability to attach arbitrary (key,value)
string pairs to a message, to remove such pairs, and to iterate
over them.  The caller should take some care as to what keys they
add or delete values for, as other subsystems or extensions may
depend on these properties.

Please see notmuch-properties(7) for more details about specific
properties and conventions around their use.
```